### PR TITLE
[Grafana dashboards] have correct query part for node and pod names

### DIFF
--- a/kubernetes/grafana-dashboards/kubernetes-pods/kubernetes-cluster.json
+++ b/kubernetes/grafana-dashboards/kubernetes-pods/kubernetes-cluster.json
@@ -2572,40 +2572,50 @@
         "type": "datasource"
       },
       {
-        "current": {
-          "text": ".*",
-          "value": ".*"
-        },
-        "hide": 0,
-        "label": null,
-        "name": "node",
-        "options": [
-          {
-            "selected": true,
-            "text": ".*",
-            "value": ".*"
-          }
-        ],
-        "query": ".*",
-        "type": "constant"
+	"allValue": ".*",
+	"current": {
+	  "text": "All",
+	  "value": "$__all"
+	},
+	"datasource": "${DS_PROMETHEUS}",
+	"hide": 0,
+	"includeAll": true,
+	"label": null,
+	"multi": false,
+	"name": "node",
+	"options": [],
+	"query": "label_values(kube_node_info, node)",
+	"refresh": 1,
+	"regex": "",
+	"sort": 2,
+	"tagValuesQuery": "",
+	"tags": [],
+	"tagsQuery": "",
+	"type": "query",
+	"useTags": false
       },
       {
-        "current": {
-          "text": ".*",
-          "value": ".*"
-        },
-        "hide": 0,
-        "label": null,
-        "name": "namespace",
-        "options": [
-          {
-            "selected": true,
-            "text": ".*",
-            "value": ".*"
-          }
-        ],
-        "query": ".*",
-        "type": "constant"
+	"allValue": ".*",
+	"current": {
+	  "text": "All",
+	  "value": "$__all"
+	},
+	"datasource": "${DS_PROMETHEUS}",
+	"hide": 0,
+	"includeAll": true,
+	"label": null,
+	"multi": false,
+	"name": "namespace",
+	"options": [],
+	"query": "label_values(kube_pod_info, namespace)",
+	"refresh": 1,
+	"regex": "",
+	"sort": 2,
+	"tagValuesQuery": "",
+	"tags": [],
+	"tagsQuery": "",
+	"type": "query",
+	"useTags": false
       }
     ]
   },

--- a/kubernetes/grafana-dashboards/kubernetes-pods/kubernetes-pods.json
+++ b/kubernetes/grafana-dashboards/kubernetes-pods/kubernetes-pods.json
@@ -586,10 +586,10 @@
         "multi": false,
         "name": "namespace",
         "options": [],
-        "query": "",
-        "refresh": 0,
+        "query": "label_values(kube_pod_info, namespace)",
+        "refresh": 1,
         "regex": "",
-        "sort": 0,
+        "sort": 2,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",
@@ -597,22 +597,27 @@
         "useTags": false
       },
       {
+        "allValue": ".*",
         "current": {
-          "text": ".*",
-          "value": ".*"
+          "text": "All",
+          "value": "$__all"
         },
+        "datasource": "${DS_PROMETHEUS}",
         "hide": 0,
+        "includeAll": true,
         "label": null,
+        "multi": false,
         "name": "pod_name",
-        "options": [
-          {
-            "selected": true,
-            "text": "",
-            "value": ""
-          }
-        ],
-        "query": "",
-        "type": "constant"
+        "options": [],
+        "query": "label_values(kube_pod_info{namespace=\"$namespace\"}, pod)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 2,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },


### PR DESCRIPTION
- This makes changes in templating sections of json files so that the
  dropdown will have namespace names, node names and pod names instead
  of blank list
- **Namespace**:
  ![screenshot from 2018-11-20 15-30-32](https://user-images.githubusercontent.com/5154532/48766602-d4156e00-ecda-11e8-9f5f-3ac326ad276e.png)
- **Node**:
  ![screenshot from 2018-11-20 15-36-14](https://user-images.githubusercontent.com/5154532/48766603-d4156e00-ecda-11e8-956e-91b65c64c43c.png)
- **Pod Name**:
  ![screenshot from 2018-11-20 15-30-18](https://user-images.githubusercontent.com/5154532/48766599-d37cd780-ecda-11e8-8741-f17e031e4aec.png)